### PR TITLE
Visual improvements

### DIFF
--- a/src/components/manage/Blocks/Accordion/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Accordion/EditBlockWrapper.jsx
@@ -86,6 +86,9 @@ class EditBlockWrapper extends React.Component {
       ? data.required
       : includes(config.blocks.requiredBlocks, type);
 
+    const allowedBlocksFromConfig =
+      blockProps.blocksConfig.accordion?.allowedBlocks;
+
     return (
       <div ref={this.blockNode}>
         <div
@@ -144,7 +147,7 @@ class EditBlockWrapper extends React.Component {
                       className="delete-button-accordion-block"
                       aria-label={intl.formatMessage(messages.delete)}
                     >
-                      <Icon name={trashSVG} size="19px" />
+                      <Icon name={trashSVG} size="19px" color="#e40166" />
                     </Button>
                   )}
                   {this.state.addNewBlockOpened && (
@@ -158,7 +161,7 @@ class EditBlockWrapper extends React.Component {
                         this.setState({ addNewBlockOpened: false });
                       }}
                       currentBlock={block}
-                      allowedBlocks={allowedBlocks}
+                      allowedBlocks={allowedBlocks || allowedBlocksFromConfig}
                     />
                   )}
                 </>

--- a/src/components/manage/Blocks/Accordion/editor.less
+++ b/src/components/manage/Blocks/Accordion/editor.less
@@ -7,6 +7,10 @@
 
 // Edit
 .block-editor-accordion {
+  .block:last-child {
+    margin-bottom: 1em;
+  }
+
   [data-rbd-draggable-context-id] {
     margin-bottom: 1rem;
   }

--- a/src/components/manage/Widgets/PanelsWidget.jsx
+++ b/src/components/manage/Widgets/PanelsWidget.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { v4 as uuid } from 'uuid';
 import { omit, without } from 'lodash';
 import move from 'lodash-move';
+import { Button } from 'semantic-ui-react';
 import { Icon, FormFieldWrapper } from '@plone/volto/components';
 import { DragDropList } from '@plone/volto/components';
 import { emptyBlocksForm } from '@plone/volto/helpers';
 
+import addSVG from '@plone/volto/icons/add.svg';
 import dragSVG from '@plone/volto/icons/drag.svg';
 import trashSVG from '@plone/volto/icons/delete.svg';
-import plusSVG from '@plone/volto/icons/circle-plus.svg';
 
 import './editor.less';
 
@@ -26,17 +27,50 @@ const empty = () => {
 };
 
 const PanelsWidget = (props) => {
-  const { value = {}, id, onChange } = props;
+  const { fieldSet, value = {}, id, onChange, schema } = props;
   const { blocks = {} } = value;
   const itemsList = (value.blocks_layout?.items || []).map((id) => [
     id,
     blocks[id],
   ]);
 
+  const objectSchema = typeof schema === 'function' ? schema(props) : schema;
+
   return (
-    <FormFieldWrapper {...props} draggable={false} className="panels-widget">
+    <div className="panels-widget">
+      <FormFieldWrapper {...props} noForInFieldLabel draggable={false}>
+        <div className="add-item-button-wrapper">
+          <Button
+            compact
+            icon
+            aria-label={objectSchema.addMessage || `Add ${objectSchema.title}`}
+            onClick={() => {
+              const [newId, newData] = empty();
+              onChange(id, {
+                ...value,
+                blocks: {
+                  ...value.blocks,
+                  [newId]: newData,
+                },
+                blocks_layout: {
+                  ...value.blocks_layout,
+                  items: [...value.blocks_layout?.items, newId],
+                },
+              });
+            }}
+          >
+            <Icon name={addSVG} size="18px" />
+            &nbsp;
+            {/* Custom addMessage in schema, else default to english */}
+            {objectSchema.addMessage || `Add ${objectSchema.title}`}
+          </Button>
+        </div>
+      </FormFieldWrapper>
       <div className="items-area">
         <DragDropList
+          forwardedAriaLabelledBy={`fieldset-${
+            fieldSet || 'default'
+          }-field-label-${id}`}
           childList={itemsList}
           onMoveItem={(result) => {
             const { source, destination } = result;
@@ -53,70 +87,56 @@ const PanelsWidget = (props) => {
           }}
         >
           {(dragProps) => {
-            const { childId, index, draginfo } = dragProps;
+            const { child, childId, index, draginfo } = dragProps;
             return (
-              <div ref={draginfo.innerRef} {...draginfo.draggableProps}>
-                <div style={{ position: 'relative' }}>
-                  <div
+              <div
+                ref={draginfo.innerRef}
+                {...draginfo.draggableProps}
+                key={childId}
+              >
+                <div className="panel-item" style={{ position: 'relative' }}>
+                  <button
                     style={{
                       visibility: 'visible',
                       display: 'inline-block',
                     }}
                     {...draginfo.dragHandleProps}
-                    className="drag handle wrapper"
+                    className="drag handle"
                   >
                     <Icon name={dragSVG} size="18px" />
+                  </button>
+                  <div className="label">
+                    {child.title || `Panel ${index + 1}`}
                   </div>
-                  <div className="item-area">
-                    <div className="label">Panel {index + 1}</div>
-                    {value.blocks_layout?.items?.length > 1 ? (
-                      <button
-                        onClick={() => {
-                          const newFormData = {
-                            ...value,
-                            blocks: omit({ ...value.blocks }, [childId]),
-                            blocks_layout: {
-                              ...value.blocks_layout,
-                              items: without(
-                                [...value.blocks_layout?.items],
-                                childId,
-                              ),
-                            },
-                          };
-                          onChange(id, newFormData);
-                        }}
-                      >
-                        <Icon name={trashSVG} size="18px" />
-                      </button>
-                    ) : (
-                      ''
-                    )}
-                  </div>
+                  {value.blocks_layout?.items?.length > 1 ? (
+                    <button
+                      onClick={() => {
+                        const newFormData = {
+                          ...value,
+                          blocks: omit({ ...value.blocks }, [childId]),
+                          blocks_layout: {
+                            ...value.blocks_layout,
+                            items: without(
+                              [...value.blocks_layout?.items],
+                              childId,
+                            ),
+                          },
+                        };
+                        onChange(id, newFormData);
+                      }}
+                    >
+                      <Icon name={trashSVG} size="18px" color="#e40166" />
+                    </button>
+                  ) : (
+                    ''
+                  )}
                 </div>
               </div>
             );
           }}
         </DragDropList>
-        <button
-          onClick={() => {
-            const [newId, newData] = empty();
-            onChange(id, {
-              ...value,
-              blocks: {
-                ...value.blocks,
-                [newId]: newData,
-              },
-              blocks_layout: {
-                ...value.blocks_layout,
-                items: [...value.blocks_layout?.items, newId],
-              },
-            });
-          }}
-        >
-          <Icon name={plusSVG} size="18px" />
-        </button>
       </div>
-    </FormFieldWrapper>
+    </div>
   );
 };
 

--- a/src/components/manage/Widgets/editor.less
+++ b/src/components/manage/Widgets/editor.less
@@ -1,6 +1,17 @@
 .panels-widget {
   .items-area {
     padding: 1em 0em;
+    margin-right: 10px;
+    margin-left: 10px;
+
+    .panel-item {
+      display: flex;
+      width: 100%;
+      justify-content: space-between;
+      padding: 12px 9px;
+      border: 1px solid #ddd;
+      background: #f3f4f5;
+    }
 
     [data-rbd-draggable-context-id] {
       margin-bottom: 0.3em;
@@ -8,19 +19,6 @@
 
     .drag.handle.wrapper {
       min-height: auto;
-    }
-
-    .item-area {
-      display: flex;
-
-      .label {
-        flex-grow: 2;
-        padding-left: 1em;
-      }
-
-      button {
-        flex-grow: 0;
-      }
     }
   }
 }


### PR DESCRIPTION
<img width="396" alt="image" src="https://user-images.githubusercontent.com/486927/132234056-32983ff9-b053-4a16-81dd-38653a996416.png">

Made the panel widget appear as much as possible like the `object_list` widget. Since this widget (panel widget) is quite different (saves an object that has the blocks/blocks_layout nested from first level) I just revamped its look and feel. I used the title as item title in the widget too, addressed some CSS issues.

Also as bonus: addressed some CSS issues in rendering and added the ability to pass an `allowedBlocks` list from the block config itself.

@avoinea What's the title for? I can see it's required, but not used in rendering at all. I can see it's uses, but does it pays off to be required?

Also, I guess next thing is to make it schemaExtender aware. What do you think?