### PR TITLE
expand customization options of titleIcons

### DIFF
--- a/src/components/manage/Blocks/Accordion/AccordionEdit.jsx
+++ b/src/components/manage/Blocks/Accordion/AccordionEdit.jsx
@@ -59,12 +59,22 @@ export default (props) => {
           })}
         >
           {isExclusive(index) ? (
-            <Icon name={titleIcons.down} size="24px" />
+            <Icon
+              name={
+                props?.data?.right_arrows
+                  ? titleIcons.closed.rightPosition
+                  : titleIcons.closed.leftPosition
+              }
+              size="24px"
+            />
           ) : (
             <Icon
               size="24px"
-              name={titleIcons.right}
-              className={cx({ 'rotate-arrow': data?.right_arrows })}
+              name={
+                props?.data?.right_arrows
+                  ? titleIcons.opened.rightPosition
+                  : titleIcons.opened.leftPosition
+              }
             />
           )}
           {!data.readOnlyTitles ? (

--- a/src/components/manage/Blocks/Accordion/View.jsx
+++ b/src/components/manage/Blocks/Accordion/View.jsx
@@ -6,10 +6,8 @@ import { withBlockExtensions } from '@plone/volto/helpers';
 
 import cx from 'classnames';
 import { Icon } from '@plone/volto/components';
-import rightSVG from '@plone/volto/icons/right-key.svg';
-import downSVG from '@plone/volto/icons/down-key.svg';
 import AnimateHeight from 'react-animate-height';
-
+import config from '@plone/volto/registry';
 import './editor.less';
 
 const View = (props) => {
@@ -17,6 +15,7 @@ const View = (props) => {
   const panels = getPanels(data.data);
   const metadata = props.metadata || props.properties;
   const [activeIndex, setActiveIndex] = React.useState([0]);
+  const { titleIcons } = config.blocks.blocksConfig.accordion;
   const handleClick = (e, itemProps) => {
     const { index } = itemProps;
     if (data.non_exclusive) {
@@ -61,14 +60,22 @@ const View = (props) => {
                 })}
               >
                 {isExclusive(index) ? (
-                  <Icon name={downSVG} size="24px" />
+                  <Icon
+                    name={
+                      props?.data?.right_arrows
+                        ? titleIcons.closed.rightPosition
+                        : titleIcons.closed.leftPosition
+                    }
+                    size="24px"
+                  />
                 ) : (
                   <Icon
-                    name={rightSVG}
+                    name={
+                      props?.data?.right_arrows
+                        ? titleIcons.opened.rightPosition
+                        : titleIcons.opened.leftPosition
+                    }
                     size="24px"
-                    className={cx({
-                      'rotate-arrow': props?.data?.right_arrows,
-                    })}
                   />
                 )}
                 <span>{panel?.title}</span>

--- a/src/components/manage/Blocks/Accordion/editor.less
+++ b/src/components/manage/Blocks/Accordion/editor.less
@@ -153,8 +153,4 @@
   .content.active {
     padding: 9px !important;
   }
-
-  .rotate-arrow {
-    transform: rotate(180deg);
-  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {
 } from './components';
 import { PanelsWidget } from '@eeacms/volto-accordion-block/components';
 import rightSVG from '@plone/volto/icons/right-key.svg';
+import leftSVG from '@plone/volto/icons/left-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';
 
 const extendedSchema = (config) => {
@@ -43,8 +44,8 @@ const applyConfig = (config) => {
     icon: accordionSVG,
     group: 'common',
     titleIcons: {
-      right: rightSVG,
-      down: downSVG,
+      closed: { leftPosition: rightSVG, rightPosition: leftSVG },
+      opened: { leftPosition: downSVG, rightPosition: downSVG },
     },
     view: AccordionBlockView,
     edit: AccordionBlockEdit,


### PR DESCRIPTION
- More options to customize the titleIcons.
- Rename the icons keys making them more generic
- Modified the View.jsx to make customization visible


Current configuration:
```
titleIcons: {
    right: rightSVG,
    down: downSVG,
},
```

The configuration I prupose is:
```
titleIcons: {
    closed: { leftPosition: rightSVG, rightPosition: leftSVG },
    opened: { leftPosition: downSVG, rightPosition: downSVG },
},
```
In this way, we can independently configure the icons when the accordion is opened and closed even when it is on the right or left.