### PR TITLE
feat: add Dutch translations.

### DIFF
--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -1,0 +1,316 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Volto Accordion Block\n"
+"POT-Creation-Date: 2023-08-24T23:48:09.459Z\n"
+"PO-Revision-Date: 2024-09-03 11:09:00+0200\n"
+"Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
+"Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: nl\n"
+"Language-Code: nl\n"
+"Language-Name: Nederlands\n"
+"Preferred-Encodings: utf-8\n"
+"Domain: volto\n"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: A short hint that describes the expected value within this block
+msgid "A short hint that describes the expected value within this block"
+msgstr "Een korte hint die de verwachte waarde binnen dit blok beschrijft"
+
+#: components/manage/Blocks/Accordion/Edit
+#: components/manage/Blocks/Accordion/Schema
+#: index
+# defaultMessage: Accordion
+msgid "Accordion"
+msgstr "Accordeon"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Accordion Title size
+msgid "Accordion Title size"
+msgstr "Grootte van titel van accordeon"
+
+#: components/manage/Blocks/Accordion/Edit
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Accordion block
+msgid "Accordion block"
+msgstr "Accordeonblok"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Accordion block settings
+msgid "Accordion block settings"
+msgstr "Instellingen accordeonblok"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Accordion theme
+msgid "Accordion theme"
+msgstr "Accordeonthema"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Accordion title
+msgid "Accordion title"
+msgstr "Accordeontitel"
+
+#: components/manage/Widgets/PanelsWidget
+# defaultMessage: Add
+msgid "Add"
+msgstr "Toevoegen"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Allow multiple panels open at a time
+msgid "Allow multiple panels open at a time"
+msgstr "Sta toe meer panelen tegelijk open te houden"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Allow only the following blocks types
+msgid "Allow only the following blocks types"
+msgstr "Sta alleen de volgende bloktypes toe"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Allowed blocks
+msgid "Allowed blocks"
+msgstr "Toegestane blokken"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Collapsed by default
+msgid "Collapsed by default"
+msgstr "Standaard ingeklapt"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Default
+msgid "Default"
+msgstr "Standaard"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Detailed expected value within this block
+msgid "Detailed expected value within this block"
+msgstr "Gedetailleerde verwachte waarde binnen dit blok"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Disable creation of new blocks after this block
+msgid "Disable creation of new blocks after this block"
+msgstr "Sta geen nieuwe blokken toe na dit blok"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Disable drag & drop on this block
+msgid "Disable drag & drop on this block"
+msgstr "Sta niet toe dit blok te verplaatsen"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Disable editing on accordion block settings
+msgid "Disable editing on accordion block settings"
+msgstr "Sta niet toe de instellingen van het accordeonblok aan te passen"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Disable editing on accordion titles
+msgid "Disable editing on accordion titles"
+msgstr "Sta niet toe accordeontitels te bewerken"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Disable editing on this block
+msgid "Disable editing on this block"
+msgstr "Sta bewerken van dit blok niet toe"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Disable inner buttons
+msgid "Disable inner buttons"
+msgstr "Schakel binnenste knoppen uit"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Disable new blocks
+msgid "Disable new blocks"
+msgstr "Sta toevoegen nieuwe blokken niet toe"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Don't allow deletion of this block
+msgid "Don't allow deletion of this block"
+msgstr "Sta niet toe dit blok te verwijderen"
+
+#: components/manage/Blocks/Accordion/EditBlockWrapper
+# defaultMessage: Drag and drop
+msgid "Drag and drop"
+msgstr "Verplaatsen"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Enable filtering
+msgid "Enable filtering"
+msgstr "Schakel filteren in"
+
+#: components/manage/Blocks/Accordion/AccordionEdit
+# defaultMessage: Enter Title
+msgid "Enter Title"
+msgstr "Geef titel op"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Fixed layout
+msgid "Fixed layout"
+msgstr "Vastgezette weergave"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Fixed layout, New panes (tabs) created by Editor within this block will be ignored
+msgid "Fixed layout, New panes (tabs) created by Editor within this block will be ignored"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Fixed position
+msgid "Fixed position"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Friendly name
+msgid "Friendly name"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Heading 2
+msgid "Heading 2"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Heading 3
+msgid "Heading 3"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Heading 4
+msgid "Heading 4"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Heading 5
+msgid "Heading 5"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Heading 6
+msgid "Heading 6"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Headline
+msgid "Headline"
+msgstr "Kop"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Helper text
+msgid "Helper text"
+msgstr "Helptekst"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Hide all block related buttons within this block
+msgid "Hide all block related buttons within this block"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Instructions
+msgid "Instructions"
+msgstr "Instructies"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Non exclusive
+msgid "Non exclusive"
+msgstr "Niet exclusief"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Options
+msgid "Options"
+msgstr "Opties"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Primary
+msgid "Primary"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Read-only
+msgid "Read-only"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Read-only settings
+msgid "Read-only settings"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Read-only titles
+msgid "Read-only titles"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/EditBlockWrapper
+# defaultMessage: Remove block
+msgid "Remove block"
+msgstr "Verwijder blok"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Required
+msgid "Required"
+msgstr "Verplicht"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Secondary
+msgid "Secondary"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+# defaultMessage: Section friendly name
+msgid "Section friendly name"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Edit
+# defaultMessage: Section help
+msgid "Section help"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Tertiary
+msgid "Tertiary"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Theme
+msgid "Theme"
+msgstr "Thema"
+
+#: components/manage/Blocks/Accordion/LayoutSchema
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Title
+msgid "Title"
+msgstr "Titel"
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Title Icon on the right
+msgid "Title Icon on the right"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/Schema
+# defaultMessage: Title size
+msgid "Title size"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/AccordionFilter
+# defaultMessage: Type to filter...
+msgid "Type to filter..."
+msgstr ""
+
+#: components/manage/Blocks/Accordion/EditBlockWrapper
+# defaultMessage: Unknown Block {block}
+msgid "Unknown Block"
+msgstr "Onbekend blok {block}"
+
+#: components/manage/Blocks/Accordion/NewBlockAddButton
+# defaultMessage: Add block in position
+msgid "add_block_in_position"
+msgstr ""
+
+#: components/manage/Blocks/Accordion/EditBlockWrapper
+# defaultMessage: delete
+msgid "delete"
+msgstr "verwijderen"
+
+#: components/manage/Widgets/PanelsWidget
+# defaultMessage: Panel {panel_index}
+msgid "panel_index"
+msgstr "Paneel {panel_index}"


### PR DESCRIPTION
Refs https://github.com/eea/volto-accordion-block/issues/111

@fredvd I did not translate all messages, as not all of them are visible in our setup, so it is hard to say if the translations make sense for those.  I guess there are some advanced options available that need integration/overrides if you want to use them.

This is how a new accordion block looks:

![Screenshot 2024-09-03 at 12 58 19](https://github.com/user-attachments/assets/9c638360-7d5a-4116-b851-41353cfa0503)

If you can confirm that is okay, then this PR can be merged.